### PR TITLE
Upgrade Firestore Database with the ability to Query

### DIFF
--- a/app/src/androidTest/java/com/github/epfl/meili/forum/ForumActivityTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/forum/ForumActivityTest.kt
@@ -115,17 +115,19 @@ class ForumActivityTest {
     }
 
     private fun setupMocks() {
-        `when`(mockFirestore.collection("forum")).thenReturn(
-            mockCollection
-        )
+        `when`(mockFirestore.collection("forum")).thenReturn(mockCollection)
 
-        `when`(mockCollection.addSnapshotListener(any())).thenAnswer { invocation ->
+        val mockQuery = mock(Query::class.java)
+        `when`(mockCollection.whereEqualTo(Post.POI_KEY_FIELD, TEST_POI_KEY)).thenReturn(mockQuery)
+
+        `when`(mockQuery.addSnapshotListener(any())).thenAnswer { invocation ->
             database = invocation.arguments[0] as AtomicPostFirestoreDatabase
             mock(ListenerRegistration::class.java)
         }
+
         `when`(mockCollection.document(contains(TEST_UID))).thenReturn(mockDocument)
 
-        `when`(mockFirestore.collection("forum${TEST_UID}/comments")).thenReturn(mockComments)
+        `when`(mockFirestore.collection("forum/${TEST_UID}/comments")).thenReturn(mockComments)
         `when`(mockComments.addSnapshotListener(any())).thenAnswer { invocation ->
             commentsDatabase = invocation.arguments[0] as FirestoreDatabase<Comment>
             mock(ListenerRegistration::class.java)
@@ -140,12 +142,16 @@ class ForumActivityTest {
         `when`(mockSnapshotAfterAddition.documents).thenReturn(listOf(mockDocumentSnapshot))
 
         // Mock poi history
-        `when`(mockFirestore.collection("poi-history/${TEST_UID}/poi-history")).thenReturn(mockPoiHistory)
+        `when`(mockFirestore.collection("poi-history/${TEST_UID}/poi-history")).thenReturn(
+            mockPoiHistory
+        )
         `when`(mockPoiHistory.addSnapshotListener(any())).thenAnswer { invocation ->
             poiDatabase = invocation.arguments[0] as FirestoreDatabase<PointOfInterest>
             mock(ListenerRegistration::class.java)
         }
-        `when`(mockPoiHistory.document(ArgumentMatchers.matches(TEST_POI_KEY))).thenReturn(mockDocument)
+        `when`(mockPoiHistory.document(ArgumentMatchers.matches(TEST_POI_KEY))).thenReturn(
+            mockDocument
+        )
 
         mockAuthenticationService.setMockUid(TEST_UID)
         mockAuthenticationService.setUsername(TEST_USERNAME)
@@ -319,17 +325,16 @@ class ForumActivityTest {
         transactionFunctionCaptor.value.apply(mockTransaction)
     }
 
-        @Test
-        fun useCameraIntentsTest() {
-            mockAuthenticationService.signInIntent()
-            database.onEvent(mockSnapshotBeforeAddition, null)
+    @Test
+    fun useCameraIntentsTest() {
+        mockAuthenticationService.signInIntent()
+        database.onEvent(mockSnapshotBeforeAddition, null)
 
-            onView(withId(R.id.create_post)).perform(click())
+        onView(withId(R.id.create_post)).perform(click())
 
-            onView(withId(R.id.post_use_camera)).perform(click())
-            Intents.intended(hasComponent(CameraActivity::class.java.name))
-        }
-
+        onView(withId(R.id.post_use_camera)).perform(click())
+        Intents.intended(hasComponent(CameraActivity::class.java.name))
+    }
 
 
 }

--- a/app/src/androidTest/java/com/github/epfl/meili/forum/ForumActivityTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/forum/ForumActivityTest.kt
@@ -58,8 +58,9 @@ class ForumActivityTest {
     companion object {
         private const val TEST_UID = "UID"
         private const val TEST_USERNAME = "AUTHOR"
-        private val TEST_POST = Post(TEST_USERNAME, "TITLE", -1, "TEXT")
-        private val TEST_POI_KEY = PointOfInterest(100.0, 100.0, "lorem_ipsum1", "lorem_ipsum2")
+        private const val TEST_POI_KEY = "lorem_ipsum2"
+        private val TEST_POST = Post(TEST_POI_KEY, TEST_USERNAME, "TITLE", -1, "TEXT")
+        private val TEST_POI = PointOfInterest(100.0, 100.0, "lorem_ipsum1", TEST_POI_KEY)
     }
 
     private val mockFirestore: FirebaseFirestore = mock(FirebaseFirestore::class.java)
@@ -85,8 +86,7 @@ class ForumActivityTest {
     private val intent = Intent(
         InstrumentationRegistry.getInstrumentation().targetContext.applicationContext,
         ForumActivity::class.java
-    )
-        .putExtra(MapActivity.POI_KEY, TEST_POI_KEY)
+    ).putExtra(MapActivity.POI_KEY, TEST_POI)
 
     @get:Rule
     var rule: ActivityScenarioRule<ForumActivity> = ActivityScenarioRule(intent)
@@ -115,7 +115,7 @@ class ForumActivityTest {
     }
 
     private fun setupMocks() {
-        `when`(mockFirestore.collection("forum/${TEST_POI_KEY.uid}/posts")).thenReturn(
+        `when`(mockFirestore.collection("forum")).thenReturn(
             mockCollection
         )
 
@@ -125,7 +125,7 @@ class ForumActivityTest {
         }
         `when`(mockCollection.document(contains(TEST_UID))).thenReturn(mockDocument)
 
-        `when`(mockFirestore.collection("forum/${TEST_POI_KEY.uid}/posts/${TEST_UID}/comments")).thenReturn(mockComments)
+        `when`(mockFirestore.collection("forum${TEST_UID}/comments")).thenReturn(mockComments)
         `when`(mockComments.addSnapshotListener(any())).thenAnswer { invocation ->
             commentsDatabase = invocation.arguments[0] as FirestoreDatabase<Comment>
             mock(ListenerRegistration::class.java)
@@ -145,7 +145,7 @@ class ForumActivityTest {
             poiDatabase = invocation.arguments[0] as FirestoreDatabase<PointOfInterest>
             mock(ListenerRegistration::class.java)
         }
-        `when`(mockPoiHistory.document(ArgumentMatchers.matches(TEST_POI_KEY.uid))).thenReturn(mockDocument)
+        `when`(mockPoiHistory.document(ArgumentMatchers.matches(TEST_POI_KEY))).thenReturn(mockDocument)
 
         mockAuthenticationService.setMockUid(TEST_UID)
         mockAuthenticationService.setUsername(TEST_USERNAME)

--- a/app/src/androidTest/java/com/github/epfl/meili/forum/ForumMenuButtonsTests.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/forum/ForumMenuButtonsTests.kt
@@ -19,11 +19,13 @@ import com.github.epfl.meili.util.MockAuthenticationService
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.Query
 import org.hamcrest.Matchers.allOf
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 
 @RunWith(AndroidJUnit4::class)
@@ -37,9 +39,13 @@ class ForumMenuButtonsTests {
     init {
         val mockFirestore: FirebaseFirestore = Mockito.mock(FirebaseFirestore::class.java)
         val mockCollection: CollectionReference = Mockito.mock(CollectionReference::class.java)
+        val mockQuery = Mockito.mock(Query::class.java)
 
         Mockito.`when`(mockFirestore.collection(any())).thenReturn(mockCollection)
+        Mockito.`when`(mockCollection.whereEqualTo(anyString(), anyString())).thenReturn(mockQuery)
+
         Mockito.`when`(mockCollection.addSnapshotListener(any())).thenAnswer { Mockito.mock(ListenerRegistration::class.java) }
+        Mockito.`when`(mockQuery.addSnapshotListener(any())).thenAnswer { Mockito.mock(ListenerRegistration::class.java) }
 
         // Inject dependencies
         FirestoreDatabase.databaseProvider = { mockFirestore }

--- a/app/src/androidTest/java/com/github/epfl/meili/forum/PostActivityTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/forum/PostActivityTest.kt
@@ -52,7 +52,7 @@ class PostActivityTest {
     companion object {
         private const val TEST_POI_KEY = "POI_KEY"
         private const val TEST_ID = "ID"
-        private val TEST_POST = Post("AUTHOR", "TITLE", -1,"TEXT")
+        private val TEST_POST = Post(TEST_POI_KEY,"AUTHOR", "TITLE", -1,"TEXT")
         private val TEST_COMMENT = Comment("AUTHOR_COMMENT", "TEXT_COMMENT")
     }
 
@@ -89,7 +89,7 @@ class PostActivityTest {
     }
 
     private fun setupMocks() {
-        Mockito.`when`(mockFirestore.collection("forum/${TEST_POI_KEY}/posts"))
+        Mockito.`when`(mockFirestore.collection("forum"))
             .thenReturn(mockCollection)
         Mockito.`when`(mockCollection.addSnapshotListener(any())).thenAnswer { invocation ->
             database = invocation.arguments[0] as AtomicPostFirestoreDatabase
@@ -98,7 +98,7 @@ class PostActivityTest {
         Mockito.`when`(mockCollection.document(ArgumentMatchers.contains(TEST_ID)))
             .thenReturn(mockDocument)
 
-        Mockito.`when`(mockFirestore.collection("forum/${TEST_POI_KEY}/posts/${TEST_ID}/comments"))
+        Mockito.`when`(mockFirestore.collection("forum/${TEST_ID}/comments"))
             .thenReturn(mockComments)
         Mockito.`when`(mockComments.addSnapshotListener(any())).thenAnswer { invocation ->
             commentsDatabase = invocation.arguments[0] as FirestoreDatabase<Comment>

--- a/app/src/androidTest/java/com/github/epfl/meili/messages/ChatLogMenuButtonsTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/messages/ChatLogMenuButtonsTest.kt
@@ -34,7 +34,7 @@ class ChatLogMenuButtonsTest {
     companion object {
         private const val TEST_UID = "UID"
         private const val TEST_USERNAME = "AUTHOR"
-        private val TEST_POST = Post(TEST_USERNAME, "TITLE", -1,"TEXT")
+        private val TEST_POST = Post("fakepoi2", TEST_USERNAME, "TITLE", -1,"TEXT")
         private const val MOCK_PATH = "POI/mock-poi"
         private const val fake_message = "fake_text"
         private const val fake_id = "fake_id"

--- a/app/src/androidTest/java/com/github/epfl/meili/messages/ChatLogMenuButtonsTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/messages/ChatLogMenuButtonsTest.kt
@@ -25,6 +25,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.contains
 import org.mockito.Mockito
 
 
@@ -34,7 +36,7 @@ class ChatLogMenuButtonsTest {
     companion object {
         private const val TEST_UID = "UID"
         private const val TEST_USERNAME = "AUTHOR"
-        private val TEST_POST = Post("fakepoi2", TEST_USERNAME, "TITLE", -1,"TEXT")
+        private val TEST_POST = Post("fakepoi2", TEST_USERNAME, "TITLE", -1, "TEXT")
         private const val MOCK_PATH = "POI/mock-poi"
         private const val fake_message = "fake_text"
         private const val fake_id = "fake_id"
@@ -69,17 +71,19 @@ class ChatLogMenuButtonsTest {
     private fun setupMocks() {
         Mockito.`when`(mockFirestore.collection((ArgumentMatchers.any())))
             .thenReturn(mockCollection)
-        Mockito.`when`(mockCollection.addSnapshotListener(ArgumentMatchers.any()))
-            .thenAnswer { invocation ->
-                Mockito.mock(ListenerRegistration::class.java)
-            }
-        Mockito.`when`(mockCollection.document(ArgumentMatchers.contains(TEST_UID)))
-            .thenReturn(mockDocument)
+        val mockQuery = Mockito.mock(Query::class.java)
+        Mockito.`when`(mockCollection.whereEqualTo(anyString(), anyString())).thenReturn(mockQuery)
+        Mockito.`when`(mockCollection.addSnapshotListener(ArgumentMatchers.any())).thenAnswer {
+            Mockito.mock(ListenerRegistration::class.java)
+        }
+        Mockito.`when`(mockQuery.addSnapshotListener(ArgumentMatchers.any())).thenAnswer {
+            Mockito.mock(ListenerRegistration::class.java)
+        }
+
+        Mockito.`when`(mockCollection.document(contains(TEST_UID))).thenReturn(mockDocument)
 
         Mockito.`when`(mockSnapshotBeforeAddition.documents)
             .thenReturn(ArrayList<DocumentSnapshot>())
-
-
 
         val mockDocumentSnapshot: DocumentSnapshot = Mockito.mock(DocumentSnapshot::class.java)
         Mockito.`when`(mockDocumentSnapshot.id).thenReturn(TEST_UID)
@@ -87,9 +91,7 @@ class ChatLogMenuButtonsTest {
             .thenReturn(TEST_POST)
         Mockito.`when`(mockSnapshotAfterAddition.documents).thenReturn(listOf(mockDocumentSnapshot))
 
-
         UiThreadStatement.runOnUiThread {
-
 
             Mockito.`when`(mockAuth.getCurrentUser())
                 .thenReturn(User("fake_uid", "fake_name", "fake_email"))
@@ -121,7 +123,6 @@ class ChatLogMenuButtonsTest {
     fun releaseIntents() {
         Intents.release()
     }
-
 
     @Test
     fun clickForumMenuButton() {

--- a/app/src/androidTest/java/com/github/epfl/meili/profile/ProfileEditableTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/profile/ProfileEditableTest.kt
@@ -4,10 +4,8 @@ import android.content.Intent
 import android.location.LocationManager
 import android.net.Uri
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
-import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -17,11 +15,8 @@ import com.github.epfl.meili.R
 import com.github.epfl.meili.database.FirebaseStorageService
 import com.github.epfl.meili.database.FirestoreDatabase
 import com.github.epfl.meili.database.FirestoreDocumentService
-import com.github.epfl.meili.feed.FeedActivity
 import com.github.epfl.meili.home.Auth
-import com.github.epfl.meili.map.MapActivity
 import com.github.epfl.meili.models.User
-import com.github.epfl.meili.profile.friends.FriendsListActivity
 import com.github.epfl.meili.util.LocationService
 import com.github.epfl.meili.util.MockAuthenticationService
 import com.google.android.gms.tasks.OnSuccessListener

--- a/app/src/androidTest/java/com/github/epfl/meili/review/ReviewMenuButtonsTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/review/ReviewMenuButtonsTest.kt
@@ -18,11 +18,13 @@ import com.github.epfl.meili.util.MockAuthenticationService
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.Query
 import org.hamcrest.Matchers
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import org.mockito.Mockito.`when`
 
@@ -38,9 +40,16 @@ class ReviewMenuButtonsTest {
     init {
         val mockFirestore: FirebaseFirestore = Mockito.mock(FirebaseFirestore::class.java)
         val mockCollection: CollectionReference = Mockito.mock(CollectionReference::class.java)
+        val mockQuery: Query = Mockito.mock(Query::class.java)
 
         `when`(mockFirestore.collection(any())).thenReturn(mockCollection)
-        `when`(mockCollection.addSnapshotListener(any())).thenAnswer { Mockito.mock(ListenerRegistration::class.java) }
+        `when`(mockCollection.whereEqualTo(anyString(), anyString())).thenReturn(mockQuery)
+        `when`(mockCollection.addSnapshotListener(any())).thenAnswer {
+            Mockito.mock(ListenerRegistration::class.java)
+        }
+        `when`(mockQuery.addSnapshotListener(any())).thenAnswer {
+            Mockito.mock(ListenerRegistration::class.java)
+        }
 
         // Inject dependencies
         FirestoreDatabase.databaseProvider = { mockFirestore }
@@ -60,8 +69,8 @@ class ReviewMenuButtonsTest {
     fun clickChatMenuButton() {
         onView(
             Matchers.allOf(
-                    withId(R.id.menu_chat),
-                    withText("Chat")
+                withId(R.id.menu_chat),
+                withText("Chat")
             )
         ).perform(click())
     }
@@ -70,9 +79,9 @@ class ReviewMenuButtonsTest {
     fun clickForumMenuButton() {
         onView(
             Matchers.allOf(
-                    withId(R.id.menu_forum),
-                    withText("Forum")
-                )
+                withId(R.id.menu_forum),
+                withText("Forum")
+            )
         ).perform(click())
     }
 }

--- a/app/src/androidTest/java/com/github/epfl/meili/review/ReviewsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/review/ReviewsActivityTest.kt
@@ -81,7 +81,9 @@ class ReviewsActivityTest {
 
     private fun setupMocks() {
         `when`(mockFirestore.collection("review/${TEST_POI_KEY}/reviews")).thenReturn(mockCollection)
-        `when`(mockCollection.addSnapshotListener(any())).thenAnswer { invocation ->
+        val mockQuery = mock(Query::class.java)
+        `when`(mockCollection.whereEqualTo(Review.POI_KEY_FIELD, TEST_POI_KEY)).thenReturn(mockQuery)
+        `when`(mockQuery.addSnapshotListener(any())).thenAnswer { invocation ->
             database = invocation.arguments[0] as FirestoreDatabase<Review>
             mock(ListenerRegistration::class.java)
         }

--- a/app/src/androidTest/java/com/github/epfl/meili/review/ReviewsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/review/ReviewsActivityTest.kt
@@ -80,7 +80,7 @@ class ReviewsActivityTest {
     }
 
     private fun setupMocks() {
-        `when`(mockFirestore.collection("review/${TEST_POI_KEY}/reviews")).thenReturn(mockCollection)
+        `when`(mockFirestore.collection("reviews")).thenReturn(mockCollection)
         val mockQuery = mock(Query::class.java)
         `when`(mockCollection.whereEqualTo(Review.POI_KEY_FIELD, TEST_POI_KEY)).thenReturn(mockQuery)
         `when`(mockQuery.addSnapshotListener(any())).thenAnswer { invocation ->

--- a/app/src/androidTest/java/com/github/epfl/meili/review/ReviewsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/epfl/meili/review/ReviewsActivityTest.kt
@@ -44,7 +44,8 @@ class ReviewsActivityTest {
     companion object {
         private const val TEST_UID = "MrPerfect"
 
-        private val TEST_POI_KEY = PointOfInterest(100.0,100.0,"lorem_ipsum1", "lorem_ipsum2")
+        private const val TEST_POI_KEY = "lorem_ipsum2"
+        private val TEST_POI = PointOfInterest(100.0,100.0,"lorem_ipsum1", TEST_POI_KEY)
         private const val TEST_TITLE = "Beach too sandy"
         private const val TEST_SUMMARY = "Water too wet"
 
@@ -79,7 +80,7 @@ class ReviewsActivityTest {
     }
 
     private fun setupMocks() {
-        `when`(mockFirestore.collection("review/${TEST_POI_KEY.uid}/reviews")).thenReturn(mockCollection)
+        `when`(mockFirestore.collection("review/${TEST_POI_KEY}/reviews")).thenReturn(mockCollection)
         `when`(mockCollection.addSnapshotListener(any())).thenAnswer { invocation ->
             database = invocation.arguments[0] as FirestoreDatabase<Review>
             mock(ListenerRegistration::class.java)
@@ -107,13 +108,13 @@ class ReviewsActivityTest {
     private fun editedReviewDocumentSnapshot(): DocumentSnapshot {
         testAverageRatingAfterEdition = (NUM_REVIEWS_BEFORE_ADDITION * testAverageRatingBeforeAddition + EDITED_REVIEW_RATING) /
                 (NUM_REVIEWS_BEFORE_ADDITION + 1)
-        return getMockDocumentSnapshot(TEST_UID, Review(EDITED_REVIEW_RATING, TEST_EDITED_TITLE, TEST_SUMMARY))
+        return getMockDocumentSnapshot(TEST_UID, Review(TEST_POI_KEY, EDITED_REVIEW_RATING, TEST_EDITED_TITLE, TEST_SUMMARY))
     }
 
     private fun addedReviewDocumentSnapshot(): DocumentSnapshot {
         testAverageRatingAfterAddition = (NUM_REVIEWS_BEFORE_ADDITION * testAverageRatingBeforeAddition + ADDED_REVIEW_RATING) /
                 (NUM_REVIEWS_BEFORE_ADDITION + 1)
-        return getMockDocumentSnapshot(TEST_UID, Review(ADDED_REVIEW_RATING, TEST_ADDED_TITLE, TEST_SUMMARY))
+        return getMockDocumentSnapshot(TEST_UID, Review(TEST_POI_KEY, ADDED_REVIEW_RATING, TEST_ADDED_TITLE, TEST_SUMMARY))
     }
 
     private fun beforeAdditionList(): MutableList<DocumentSnapshot> {
@@ -121,7 +122,7 @@ class ReviewsActivityTest {
         val documentList: MutableList<DocumentSnapshot> = ArrayList()
 
         for (i in 1..NUM_REVIEWS_BEFORE_ADDITION) {
-            val review = Review(i.toFloat() / 2, TEST_TITLE, TEST_SUMMARY)
+            val review = Review(TEST_POI_KEY, i.toFloat() / 2, TEST_TITLE, TEST_SUMMARY)
             reviews[i.toString()] = review
             documentList.add(getMockDocumentSnapshot(i.toString(), review))
         }
@@ -138,7 +139,7 @@ class ReviewsActivityTest {
     }
 
     private val intent = Intent(getInstrumentation().targetContext.applicationContext, ReviewsActivity::class.java)
-                            .putExtra("POI_KEY", TEST_POI_KEY)
+                            .putExtra("POI_KEY", TEST_POI)
 
     @get:Rule
     var rule: ActivityScenarioRule<ReviewsActivity> = ActivityScenarioRule(intent)

--- a/app/src/main/java/com/github/epfl/meili/database/AtomicPostFirestoreDatabase.kt
+++ b/app/src/main/java/com/github/epfl/meili/database/AtomicPostFirestoreDatabase.kt
@@ -1,8 +1,13 @@
 package com.github.epfl.meili.database
 
 import com.github.epfl.meili.models.Post
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.Query
 
-class AtomicPostFirestoreDatabase(path: String) : FirestoreDatabase<Post>(path, Post::class.java) {
+class AtomicPostFirestoreDatabase(
+    path: String,
+    query: (CollectionReference) -> Query = { it }
+) : FirestoreDatabase<Post>(path, Post::class.java, query) {
     companion object {
         private const val upVoters = "upvoters"
         private const val downVoters = "downvoters"
@@ -10,11 +15,11 @@ class AtomicPostFirestoreDatabase(path: String) : FirestoreDatabase<Post>(path, 
 
     @Suppress("UNCHECKED_CAST")
     fun upDownVote(key: String, userUid: String, isUpvote: Boolean) {
-        val sfDocRef = ref.document(key)
+        val sfDocRef = collectionReference.document(key)
         databaseProvider().runTransaction { transaction ->
             val snapshot = transaction.get(sfDocRef)
-            val fieldName: String = if(isUpvote) upVoters else downVoters
-            val otherFieldName: String = if(isUpvote) downVoters else upVoters
+            val fieldName: String = if (isUpvote) upVoters else downVoters
+            val otherFieldName: String = if (isUpvote) downVoters else upVoters
             val voters = ArrayList(snapshot.get(fieldName)!! as List<String>)
             val otherVoters = ArrayList(snapshot.get(otherFieldName)!! as List<String>)
             if (voters.contains(userUid)) {
@@ -26,10 +31,8 @@ class AtomicPostFirestoreDatabase(path: String) : FirestoreDatabase<Post>(path, 
                 voters.add(userUid)
             }
 
-            //update to new up/downvoters list
             transaction.update(sfDocRef, fieldName, voters)
             transaction.update(sfDocRef, otherFieldName, otherVoters)
         }
     }
-
 }

--- a/app/src/main/java/com/github/epfl/meili/database/FirestoreDatabase.kt
+++ b/app/src/main/java/com/github/epfl/meili/database/FirestoreDatabase.kt
@@ -25,7 +25,6 @@ open class FirestoreDatabase<T: Any>(path: String, private val ofClass: Class<T>
         ref.document(key).set(element!!)
     }
 
-
     override fun onDestroy() {
         registration.remove()
     }

--- a/app/src/main/java/com/github/epfl/meili/database/FirestoreDatabase.kt
+++ b/app/src/main/java/com/github/epfl/meili/database/FirestoreDatabase.kt
@@ -17,12 +17,12 @@ open class FirestoreDatabase<T : Any>(
 
     override var elements: Map<String, T> = HashMap()
 
-    protected val ref = databaseProvider().collection(path)
+    protected val collectionReference = databaseProvider().collection(path)
 
-    private val registration = query(ref).addSnapshotListener(this)
+    private val registration = query(collectionReference).addSnapshotListener(this)
 
     override fun addElement(key: String, element: T?) {
-        ref.document(key).set(element!!)
+        collectionReference.document(key).set(element!!)
     }
 
     override fun onEvent(snapshot: QuerySnapshot?, error: FirebaseFirestoreException?) {

--- a/app/src/main/java/com/github/epfl/meili/database/FirestoreDatabase.kt
+++ b/app/src/main/java/com/github/epfl/meili/database/FirestoreDatabase.kt
@@ -3,7 +3,11 @@ package com.github.epfl.meili.database
 import android.util.Log
 import com.google.firebase.firestore.*
 
-open class FirestoreDatabase<T: Any>(path: String, private val ofClass: Class<T>) : Database<T>(), EventListener<QuerySnapshot> {
+open class FirestoreDatabase<T : Any>(
+    path: String,
+    private val ofClass: Class<T>,
+    query: (CollectionReference) -> Query = { it }
+) : Database<T>(), EventListener<QuerySnapshot> {
 
     companion object {
         private const val TAG: String = "FirestoreDatabase"
@@ -13,20 +17,12 @@ open class FirestoreDatabase<T: Any>(path: String, private val ofClass: Class<T>
 
     override var elements: Map<String, T> = HashMap()
 
-    private val registration: ListenerRegistration
+    protected val ref = databaseProvider().collection(path)
 
-    val ref: CollectionReference = databaseProvider().collection(path)
-
-    init {
-        registration = ref.addSnapshotListener(this)
-    }
+    private val registration = query(ref).addSnapshotListener(this)
 
     override fun addElement(key: String, element: T?) {
         ref.document(key).set(element!!)
-    }
-
-    override fun onDestroy() {
-        registration.remove()
     }
 
     override fun onEvent(snapshot: QuerySnapshot?, error: FirebaseFirestoreException?) {
@@ -47,5 +43,9 @@ open class FirestoreDatabase<T: Any>(path: String, private val ofClass: Class<T>
         } else {
             Log.e(TAG, "Received null snapshot from Firestore")
         }
+    }
+
+    override fun onDestroy() {
+        registration.remove()
     }
 }

--- a/app/src/main/java/com/github/epfl/meili/forum/ForumActivity.kt
+++ b/app/src/main/java/com/github/epfl/meili/forum/ForumActivity.kt
@@ -176,8 +176,9 @@ class ForumActivity : MenuActivity(R.menu.nav_forum_menu), AdapterView.OnItemSel
     private fun initViewModel() {
         @Suppress("UNCHECKED_CAST")
         viewModel = ViewModelProvider(this).get(ForumViewModel::class.java)
-        val poiKey = poi.uid
-        viewModel.initDatabase(AtomicPostFirestoreDatabase("forum"))
+        viewModel.initDatabase(AtomicPostFirestoreDatabase("forum") {
+            it.whereEqualTo(Post.POI_KEY_FIELD, poi.uid)
+        })
         if (Auth.getCurrentUser() != null) {
             viewModel.initFavoritePoisDatabase(
                 FirestoreDatabase( // add to poi favorites

--- a/app/src/main/java/com/github/epfl/meili/forum/ForumActivity.kt
+++ b/app/src/main/java/com/github/epfl/meili/forum/ForumActivity.kt
@@ -164,9 +164,7 @@ class ForumActivity : MenuActivity(R.menu.nav_forum_menu), AdapterView.OnItemSel
         val title = editTitleView.text.toString()
         val text = editTextVIew.text.toString()
 
-        viewModel.addElement(postId, Post(user.username, title, timestamp, text))
-
-
+        viewModel.addElement(postId, Post(poi.uid, user.username, title, timestamp, text))
 
         if (bitmap != null) {
             executor.execute { compressAndUploadToFirebase("images/forum/$postId", bitmap!!) }
@@ -179,7 +177,7 @@ class ForumActivity : MenuActivity(R.menu.nav_forum_menu), AdapterView.OnItemSel
         @Suppress("UNCHECKED_CAST")
         viewModel = ViewModelProvider(this).get(ForumViewModel::class.java)
         val poiKey = poi.uid
-        viewModel.initDatabase(AtomicPostFirestoreDatabase("forum/$poiKey/posts"))
+        viewModel.initDatabase(AtomicPostFirestoreDatabase("forum"))
         if (Auth.getCurrentUser() != null) {
             viewModel.initFavoritePoisDatabase(
                 FirestoreDatabase( // add to poi favorites

--- a/app/src/main/java/com/github/epfl/meili/forum/PostActivity.kt
+++ b/app/src/main/java/com/github/epfl/meili/forum/PostActivity.kt
@@ -91,7 +91,7 @@ class PostActivity : AppCompatActivity() {
         @Suppress("UNCHECKED_CAST")
         viewModel = ViewModelProvider(this).get(MeiliViewModel::class.java) as MeiliViewModel<Comment>
 
-        viewModel.initDatabase(FirestoreDatabase("forum/$poiKey/posts/$postId/comments", Comment::class.java))
+        viewModel.initDatabase(FirestoreDatabase("forum/$postId/comments", Comment::class.java))
         viewModel.getElements().observe(this, { map ->
             recyclerAdapter.submitList(map.toList())
             recyclerAdapter.notifyDataSetChanged()

--- a/app/src/main/java/com/github/epfl/meili/models/Post.kt
+++ b/app/src/main/java/com/github/epfl/meili/models/Post.kt
@@ -16,5 +16,6 @@ data class Post(
 ) : Parcelable {
     companion object {
         const val TAG = "Post"
+        const val POI_KEY_FIELD = "poiKey"
     }
 }

--- a/app/src/main/java/com/github/epfl/meili/models/Post.kt
+++ b/app/src/main/java/com/github/epfl/meili/models/Post.kt
@@ -5,6 +5,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Post(
+    var poiKey: String = "",
     var author: String = "",
     var title: String = "",
     val timestamp: Long = -1,

--- a/app/src/main/java/com/github/epfl/meili/models/Review.kt
+++ b/app/src/main/java/com/github/epfl/meili/models/Review.kt
@@ -5,13 +5,12 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class Review (
+    var poiKey: String = "",
     var rating: Float = 0f,
     var title: String = "",
-    var summary: String = ""
+    var summary: String = "",
 ): Parcelable {
     companion object {
-        private const val TAG = "Review"
-
         fun averageRating(reviews: Map<String, Review>): Float {
             return if (reviews.isEmpty()) {
                 0f

--- a/app/src/main/java/com/github/epfl/meili/models/Review.kt
+++ b/app/src/main/java/com/github/epfl/meili/models/Review.kt
@@ -8,9 +8,11 @@ data class Review (
     var poiKey: String = "",
     var rating: Float = 0f,
     var title: String = "",
-    var summary: String = "",
+    var summary: String = ""
 ): Parcelable {
     companion object {
+        const val POI_KEY_FIELD = "poiKey"
+
         fun averageRating(reviews: Map<String, Review>): Float {
             return if (reviews.isEmpty()) {
                 0f

--- a/app/src/main/java/com/github/epfl/meili/profile/ProfileActivity.kt
+++ b/app/src/main/java/com/github/epfl/meili/profile/ProfileActivity.kt
@@ -11,8 +11,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.ViewModelProvider
 import com.github.epfl.meili.R
 import com.github.epfl.meili.home.Auth
-import com.github.epfl.meili.profile.friends.FriendsListActivity
 import com.github.epfl.meili.profile.favoritepois.FavoritePoisActivity
+import com.github.epfl.meili.profile.friends.FriendsListActivity
 import com.github.epfl.meili.util.NavigableActivity
 import com.github.epfl.meili.util.UIUtility
 import com.google.android.material.floatingactionbutton.FloatingActionButton

--- a/app/src/main/java/com/github/epfl/meili/profile/friends/FriendsListActivity.kt
+++ b/app/src/main/java/com/github/epfl/meili/profile/friends/FriendsListActivity.kt
@@ -17,7 +17,6 @@ import com.github.epfl.meili.messages.ChatLogActivity
 import com.github.epfl.meili.models.Friend
 import com.github.epfl.meili.models.User
 import com.github.epfl.meili.profile.ProfileActivity
-import com.github.epfl.meili.profile.friends.NearbyActivity
 import com.github.epfl.meili.util.ClickListener
 import com.github.epfl.meili.util.MeiliViewModel
 import com.github.epfl.meili.util.TopSpacingItemDecoration

--- a/app/src/main/java/com/github/epfl/meili/review/ReviewsActivity.kt
+++ b/app/src/main/java/com/github/epfl/meili/review/ReviewsActivity.kt
@@ -93,8 +93,8 @@ class ReviewsActivity : MenuActivity(R.menu.nav_review_menu) {
         val title = editTitleView.text.toString()
         val summary = editSummaryView.text.toString()
 
-        val userKey = Auth.getCurrentUser()!!.uid
-        viewModel.addElement(userKey, Review(poi.uid, rating, title, summary))
+        val key = Auth.getCurrentUser()!!.uid + poi.uid
+        viewModel.addElement(key, Review(poi.uid, rating, title, summary))
     }
 
     private fun editReviewButtonListener() {

--- a/app/src/main/java/com/github/epfl/meili/review/ReviewsActivity.kt
+++ b/app/src/main/java/com/github/epfl/meili/review/ReviewsActivity.kt
@@ -122,7 +122,10 @@ class ReviewsActivity : MenuActivity(R.menu.nav_review_menu) {
         viewModel =
             ViewModelProvider(this).get(MeiliViewModel::class.java) as MeiliViewModel<Review>
 
-        viewModel.initDatabase(FirestoreDatabase("reviews", Review::class.java))
+        viewModel.initDatabase(FirestoreDatabase("reviews", Review::class.java) {
+            it.whereEqualTo(Review.POI_KEY_FIELD, poiKey)
+        })
+
         viewModel.getElements().observe(this, { map ->
             reviewsMapListener(map)
         })

--- a/app/src/main/java/com/github/epfl/meili/review/ReviewsActivity.kt
+++ b/app/src/main/java/com/github/epfl/meili/review/ReviewsActivity.kt
@@ -94,7 +94,7 @@ class ReviewsActivity : MenuActivity(R.menu.nav_review_menu) {
         val summary = editSummaryView.text.toString()
 
         val userKey = Auth.getCurrentUser()!!.uid
-        viewModel.addElement(userKey, Review(rating, title, summary))
+        viewModel.addElement(userKey, Review(poi.uid, rating, title, summary))
     }
 
     private fun editReviewButtonListener() {
@@ -122,7 +122,7 @@ class ReviewsActivity : MenuActivity(R.menu.nav_review_menu) {
         viewModel =
             ViewModelProvider(this).get(MeiliViewModel::class.java) as MeiliViewModel<Review>
 
-        viewModel.initDatabase(FirestoreDatabase("review/$poiKey/reviews", Review::class.java))
+        viewModel.initDatabase(FirestoreDatabase("reviews", Review::class.java))
         viewModel.getElements().observe(this, { map ->
             reviewsMapListener(map)
         })

--- a/app/src/test/java/com/github/epfl/meili/models/ReviewUnitTest.kt
+++ b/app/src/test/java/com/github/epfl/meili/models/ReviewUnitTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class ReviewUnitTest {
 
     companion object {
-        private const val TEST_RATING: Float = 3f
+        private const val TEST_POI_KEY = "POI"
         private const val TEST_TITLE : String = "Beach Too Sandy"
         private const val TEST_SUMMARY: String = "Water Too Wet"
     }
@@ -14,12 +14,12 @@ class ReviewUnitTest {
     @Test
     fun averageRatingCalculationTest() {
         val reviewMap: MutableMap<String, Review> = HashMap()
-        val range: IntRange = IntRange(1, 5)
+        val range = IntRange(1, 5)
 
-        var averageRating: Float = 0f
+        var averageRating = 0f
 
         for (i in range) {
-            reviewMap[i.toString()] = Review(i.toFloat(), TEST_TITLE, TEST_SUMMARY)
+            reviewMap[i.toString()] = Review(TEST_POI_KEY, i.toFloat(), TEST_TITLE, TEST_SUMMARY)
             averageRating += i.toFloat()
         }
 


### PR DESCRIPTION
Upgrade FirestoreDatabase with the ability to accept a query, with the the trivial query (always true) being the default one to ensure backwards compatibility.

Changes firestore paths for forum and reviews to make them query-able:
- forum/uid/posts/ -> forum/
- review/uid/reviews/ -> reviews/

The uid of the poi is instead stored inside the post or the review document.